### PR TITLE
FISH-338 Write Hashicorp Test

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/config-extensions/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/pom.xml
@@ -91,5 +91,15 @@
             <artifactId>oauth2-client-integration</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/hashicorp/HashiCorpSecretsConfigSource.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/main/java/fish/payara/microprofile/config/extensions/hashicorp/HashiCorpSecretsConfigSource.java
@@ -81,7 +81,7 @@ public class HashiCorpSecretsConfigSource extends ConfiguredExtensionConfigSourc
     private static final Logger LOGGER = Logger.getLogger(HashiCorpSecretsConfigSource.class.getName());
 
     private Client client = ClientBuilder.newClient();
-    private String hashiCorpVaultToken;
+    protected String hashiCorpVaultToken;
     private final ObjectMapper mapper = new ObjectMapper();
 
     @Override
@@ -191,7 +191,7 @@ public class HashiCorpSecretsConfigSource extends ConfiguredExtensionConfigSourc
 
                     parser.next();
                     if ("data".equals(keyName)) {
-                        return parser.getObject().getJsonObject(keyName).toString();
+                        return parser.getObject().toString();
                     }
                 }
             }

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/src/test/java/fish/payara/microprofile/config/extensions/hashicorp/HashiCorpSecretsConfigSourceTest.java
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/src/test/java/fish/payara/microprofile/config/extensions/hashicorp/HashiCorpSecretsConfigSourceTest.java
@@ -1,0 +1,64 @@
+package fish.payara.microprofile.config.extensions.hashicorp;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HashiCorpSecretsConfigSourceTest {
+
+    private static final String FAKE_ENDPOINT = "http://fake-endpoint";
+    private static final String FAKE_TOKEN = "FAKE_TOKEN";
+
+    private static final String GET_RESULT = "{\"request_id\":\"666f6576-8e81-5938-fcc8-bc8fe914c219\",\"lease_id\":\"\",\"renewable\":false,\"lease_duration\":36000,\"data\":{\"key\":\"value\"},\"wrap_info\":null,\"warnings\":null,\"auth\":null}";
+
+    @Mock
+    private Client client;
+
+    @InjectMocks
+    private HashiCorpSecretsConfigSource configSource = new HashiCorpSecretsConfigSource();
+
+    @Before
+    public void initMocks() {
+        // Create fake config that returns the fake endpoint address
+        final HashiCorpSecretsConfigSourceConfiguration config = mock(HashiCorpSecretsConfigSourceConfiguration.class);
+        when(config.getVaultAddress()).thenReturn(FAKE_ENDPOINT);
+        configSource.setConfiguration(config);
+
+        // Configure the vault token
+        configSource.hashiCorpVaultToken = FAKE_TOKEN;
+
+        // Create fake web target to return the expected response
+        final WebTarget fakeTarget = mock(WebTarget.class);
+        when(client.target(FAKE_ENDPOINT)).thenReturn(fakeTarget);
+        final Invocation.Builder fakeBuilder = mock(Invocation.Builder.class);
+        when(fakeTarget.request()).thenReturn(fakeBuilder);
+        when(fakeBuilder.accept(MediaType.APPLICATION_JSON)).thenReturn(fakeBuilder);
+        when(fakeBuilder.header("Authorization", "Bearer " + FAKE_TOKEN)).thenReturn(fakeBuilder);
+        final Response fakeResponse = mock(Response.class);
+        when(fakeBuilder.get()).thenReturn(fakeResponse);
+        when(fakeResponse.getStatus()).thenReturn(200);
+        when(fakeResponse.getEntity()).thenReturn(new ByteArrayInputStream(GET_RESULT.getBytes()));
+    }
+
+    @Test
+    public void test() {
+        assertEquals("Incorrect property value", "value", configSource.getValue("key"));
+    }
+    
+}


### PR DESCRIPTION
Fix deserialisation error and write test for fetching properties from the config source. @MeroRai can you test again for me? The `getJsonObject(keyName)` code didn't work for me. Feel free to call me.